### PR TITLE
Reconnect to eD2k server when a TCP port remap is confirmed after login

### DIFF
--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -65,6 +65,11 @@ struct ServerConnectResult {
     addr: SocketAddr,
     ip: String,
     port: u16,
+    /// Our own TCP port as sent in this attempt's `OP_LOGINREQUEST` — NOT
+    /// the server's `port` above. Recorded into
+    /// `NetworkState::server_login_tcp_port` on success so a later
+    /// STUN-confirmed remap can detect it needs a reconnect.
+    login_tcp_port: u16,
     result: Result<(Ed2kServerConnection, ServerSession), String>,
 }
 
@@ -449,6 +454,41 @@ fn apply_udp_mapping_keepalive(
         );
     }
     true
+}
+
+/// Minimum gap between mapping-keep-alive-triggered eD2k reconnects (see the
+/// `tcp_map_ka_result_rx` arm). The two-hit confirmation gate already makes
+/// back-to-back *different* confirmed values ~40s apart at best; this is an
+/// explicit floor on top of that so a pathologically unstable mapping can't
+/// reconnect-thrash the server session faster than this.
+const TCP_REMAP_RECONNECT_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Whether the mapping keep-alive should force a reconnect to the currently
+/// connected eD2k server to push a STUN-confirmed TCP port remap that
+/// arrived after login. eD2k has no "update my port" message once logged
+/// in, so a remap confirmed later (the common case — confirmation needs two
+/// keep-alive cycles, ~40s, which can easily land after an
+/// already-in-progress login) would otherwise sit unused until some
+/// unrelated reconnect. Only reconnects when it can actually help (still
+/// LowID, actually connected, no reconnect already in flight), only for a
+/// value the server doesn't already have on file, and never faster than
+/// `TCP_REMAP_RECONNECT_COOLDOWN` — a per-value cooldown already falls out
+/// of the two-hit confirmation gate, but this adds an explicit floor so a
+/// pathologically unstable mapping can't reconnect-thrash the session.
+fn should_reconnect_for_tcp_remap(
+    low_id: bool,
+    server_connected: bool,
+    reconnect_in_flight: bool,
+    confirmed_port: Option<u16>,
+    server_login_tcp_port: Option<u16>,
+    cooldown_elapsed: bool,
+) -> bool {
+    low_id
+        && server_connected
+        && !reconnect_in_flight
+        && cooldown_elapsed
+        && confirmed_port.is_some()
+        && confirmed_port != server_login_tcp_port
 }
 
 /// Outcome of one twin-STUN TCP-port observation against the current TCP
@@ -2412,6 +2452,60 @@ mod tests {
         assert_eq!(second.confirmed_port, Some(51234));
         assert_eq!(second.candidate_port, None);
         assert_eq!(second.stable_hits, 0);
+    }
+
+    #[test]
+    fn should_reconnect_for_tcp_remap_when_lowid_with_a_new_confirmed_port() {
+        assert!(should_reconnect_for_tcp_remap(
+            true, true, false, Some(51234), Some(4662), true
+        ));
+    }
+
+    #[test]
+    fn should_not_reconnect_for_tcp_remap_when_already_highid() {
+        // Nothing to fix — reconnecting would only risk disrupting a
+        // perfectly good HighID session.
+        assert!(!should_reconnect_for_tcp_remap(
+            false, true, false, Some(51234), Some(4662), true
+        ));
+    }
+
+    #[test]
+    fn should_not_reconnect_for_tcp_remap_when_disconnected() {
+        assert!(!should_reconnect_for_tcp_remap(
+            true, false, false, Some(51234), Some(4662), true
+        ));
+    }
+
+    #[test]
+    fn should_not_reconnect_for_tcp_remap_when_reconnect_already_in_flight() {
+        assert!(!should_reconnect_for_tcp_remap(
+            true, true, true, Some(51234), Some(4662), true
+        ));
+    }
+
+    #[test]
+    fn should_not_reconnect_for_tcp_remap_when_port_unconfirmed() {
+        assert!(!should_reconnect_for_tcp_remap(
+            true, true, false, None, Some(4662), true
+        ));
+    }
+
+    #[test]
+    fn should_not_reconnect_for_tcp_remap_when_server_already_has_this_port() {
+        // The server already knows this exact port (either it was current
+        // at login, or a prior reconnect already pushed it) — nothing to
+        // gain from reconnecting again.
+        assert!(!should_reconnect_for_tcp_remap(
+            true, true, false, Some(51234), Some(51234), true
+        ));
+    }
+
+    #[test]
+    fn should_not_reconnect_for_tcp_remap_during_cooldown() {
+        assert!(!should_reconnect_for_tcp_remap(
+            true, true, false, Some(51234), Some(4662), false
+        ));
     }
 
     #[test]
@@ -4692,6 +4786,23 @@ struct NetworkState {
     low_id: bool,
     /// Our server-assigned client ID
     server_client_id: u32,
+    /// The TCP port we actually sent in the last successful `OP_LOGINREQUEST`
+    /// to the currently-connected server. eD2k has no "update my port"
+    /// message once logged in — the server only learns a new port by us
+    /// reconnecting — so this lets the mapping keep-alive notice a
+    /// STUN-confirmed remap that arrived *after* login and trigger a
+    /// reconnect while still LowID (see the `tcp_map_ka_result_rx` arm).
+    /// `None` while disconnected; irrelevant then since the reconnect check
+    /// is gated on `server_connected`.
+    server_login_tcp_port: Option<u16>,
+    /// Last time the mapping keep-alive triggered a reconnect to push a
+    /// newly confirmed TCP port to the server (see `tcp_map_ka_result_rx`).
+    /// A per-value cooldown already falls out of the two-hit confirmation
+    /// gate (`tcp_port_confirmation`), but this adds an explicit floor so a
+    /// pathologically unstable mapping (a "confirmed" port that keeps
+    /// changing every couple of cycles) can't reconnect-thrash the server
+    /// session faster than this.
+    last_tcp_remap_reconnect_at: Option<std::time::Instant>,
     /// Background server connection task (non-blocking)
     pending_server_connect: Option<tokio::task::JoinHandle<ServerConnectResult>>,
     /// Shared set of user hashes expected as incoming buddy connections (checked by upload listener)
@@ -5827,6 +5938,7 @@ async fn initiate_server_connect(
             addr,
             ip,
             port,
+            login_tcp_port: tcp_port,
             result: result.map(|(conn, session, _)| (conn, session)),
         }
     }));
@@ -7479,6 +7591,8 @@ pub async fn start_network(
         udp_fw_node_search: None,
         low_id: false,
         server_client_id: 0,
+        server_login_tcp_port: None,
+        last_tcp_remap_reconnect_at: None,
         pending_server_connect: None,
         pending_buddy_hashes: pending_buddy_hashes.clone(),
         shared_buddy_info: shared_buddy_info.clone(),
@@ -19821,6 +19935,7 @@ pub async fn start_network(
                                 addr,
                                 ip,
                                 port,
+                                login_tcp_port: tcp_port,
                                 result: result.map(|(conn, session, _)| (conn, session)),
                             }
                         }));
@@ -20423,7 +20538,7 @@ pub async fn start_network(
             } => {
                 state.pending_server_connect = None;
                 match result {
-                    Ok(ServerConnectResult { addr, ip, port, result: Ok((mut conn, session)) }) => {
+                    Ok(ServerConnectResult { addr, ip, port, login_tcp_port, result: Ok((mut conn, session)) }) => {
                         // Check server IP against IP filter (eMule: FilterServerByIP)
                         if settings.filter_servers_by_ip {
                             let server_ipv4 = match addr.ip() {
@@ -20474,6 +20589,7 @@ pub async fn start_network(
                         ));
                         state.low_id = is_low;
                         state.server_client_id = session.client_id;
+                        state.server_login_tcp_port = Some(login_tcp_port);
                         state.server_list.record_success(&ip, port);
                         state.server_connected = true;
                         state.server_reconnect_failures = 0;
@@ -21914,6 +22030,38 @@ pub async fn start_network(
                 }
                 if apply_tcp_mapping_keepalive(&mut state, result.hold_ok, result.mapped, &app_handle) {
                     mapping_ka_cycle_success = true;
+                }
+                // A reconnect that fails just falls back to the existing
+                // backoff-driven auto-reconnect (which will use the
+                // now-current `advertised_tcp_port` anyway) — see
+                // `should_reconnect_for_tcp_remap` for the full rationale.
+                let cooldown_elapsed = state
+                    .last_tcp_remap_reconnect_at
+                    .is_none_or(|at| at.elapsed() >= TCP_REMAP_RECONNECT_COOLDOWN);
+                if should_reconnect_for_tcp_remap(
+                    state.low_id,
+                    state.server_connected,
+                    state.pending_server_connect.is_some(),
+                    state.external_tcp_port,
+                    state.server_login_tcp_port,
+                    cooldown_elapsed,
+                ) {
+                    if let Some(addr) = state.server_addr {
+                        info!(
+                            "STUN keepalive: public TCP port confirmed as {:?} (server has {:?}) while LowID — reconnecting to eD2k server for a fresh HighID check",
+                            state.external_tcp_port, state.server_login_tcp_port
+                        );
+                        state.last_tcp_remap_reconnect_at = Some(std::time::Instant::now());
+                        initiate_server_connect(
+                            &mut state,
+                            &settings,
+                            &app_handle,
+                            &shared_server_addr,
+                            addr.ip().to_string(),
+                            addr.port(),
+                        )
+                        .await;
+                    }
                 }
                 if !udp_map_ka_in_flight && !tcp_map_ka_in_flight && !mapping_ka_cycle_success {
                     if state.stats.stun_keepalive_active {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Follow-up to #42 (the STUN keep-alive TCP-port-advertising fix). That fix resolved the caveat that the previously-implemented mechanism was a complete no-op that guaranteed the wrong port was always advertised. This closes a residual timing gap in the original design (not introduced by #42): eD2k has no "update my TCP port" protocol message once a client has logged in — the server only ever learns the port from the `OP_LOGINREQUEST` sent at login time. The STUN keep-alive's TCP-port confirmation needs two ~20s cycles (~40s) to trust a reading, which can easily land after login already happened. Without this change, a corrected port would sit unused — correctly advertised to peers/KAD via `advertise_tcp_port`, but invisible to the already-connected eD2k server — until some unrelated reconnect happened to occur.

## What changed

- Added `NetworkState::server_login_tcp_port`, populated from a new `ServerConnectResult::login_tcp_port` field, recording the TCP port actually sent in the last successful login.
- When the mapping keep-alive confirms a TCP port different from what the server has on file, **and** we're still LowID, **and** we're actually connected, it now triggers a reconnect through the existing `initiate_server_connect` path (the same function already used by manual "Connect" and the auto-reconnect background task) so the server re-learns the corrected port and can retry its HighID connect-back.
- The reconnect decision is extracted into a small, pure, unit-tested helper (`should_reconnect_for_tcp_remap`), mirroring the `tcp_port_confirmation` helper from #42.

## Why this shouldn't cause other issues

- **Only fires while LowID.** An already-working HighID session is left completely alone — there's nothing to gain from reconnecting it.
- **Only fires once per distinct confirmed value.** `server_login_tcp_port` is refreshed on every successful login, so the same confirmed port can't retrigger a reconnect.
- **Explicit 60s cooldown** (`TCP_REMAP_RECONNECT_COOLDOWN`) on top of the pre-existing two-hit stability gate (`tcp_port_confirmation`, from #42), so even a pathologically unstable NAT mapping can't reconnect-thrash the server session.
- **No new reconnect machinery.** It reuses `initiate_server_connect` verbatim — the same disconnect/reconnect/login path already exercised by manual reconnects and the existing auto-reconnect backoff logic. A failed attempt just falls back to that pre-existing backoff-driven retry, which will use the now-current `advertised_tcp_port` anyway.
- **Doesn't touch KAD/UDP.** KAD Hello/publish packets already read the live `advertise_tcp_port` atomic on every send, so they were never affected by this staleness — this change is scoped only to the eD2k TCP server login path.

## Testing

- `cargo build --lib` — clean (only the pre-existing unrelated `ENTROPY` warning).
- `cargo test --lib` — all tests pass except the same 3 pre-existing, unrelated `commands::settings::tests::*` failures caused by a sandbox `/tmp` path quirk (reproduced identically on `main`).
- Added 7 unit tests for `should_reconnect_for_tcp_remap` covering: the happy path, and each individual gate (already-HighID, disconnected, reconnect-in-flight, port-unconfirmed, server-already-has-this-port, cooldown-active).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ece1c635-bfe5-4623-8ad4-f8fa6a493b93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ece1c635-bfe5-4623-8ad4-f8fa6a493b93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

