### PR TITLE
Document the NAT traversal stack: QUIC, STUN, and the rest are not interchangeable

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ Ember's own additions — the [Ember Network](#ember-network) overlay and the [E
 - **KAD Network & eD2K Servers** — Connect to the decentralized KAD DHT and traditional eD2K servers for peer discovery and search. A community `server.met` can be downloaded from emule-security.org, and fresh KAD `nodes.dat` bootstrap contacts can be fetched from Settings → Network when KAD will not connect.
 - **Auto-Connect** — Optionally reconnect KAD and your last eD2K server on launch; with no server history, Auto-Connect Server falls back to eMule Sunrise.
 - **EPX Source Exchange** — Ember peers share source lists with each other for faster downloads (see above).
-- **NAT Traversal** — UPnP automatic port mapping, firewall detection, KAD buddy relay for LowID peers, and EPX peer-relay (ERAT) for LowID↔LowID paths when attestations allow.
-- **STUN Port Keep-Alive** — Periodic STUN plus a TCP hold from the listen port keeps NAT mappings alive and advertises the discovered public ports for HighID. Aimed at CGNAT and full-cone NAT without UPnP; auto-suspends on symmetric or unstable remapping.
+- **NAT Traversal** — Layered fallbacks, not one mechanism: UPnP port mapping, KAD firewall checks, STUN keep-alive, Ember QUIC hole-punch, KAD buddy, EPX peer-relay (ERAT), and a friend-only WebSocket relay. A session uses a subset; the stack as a whole is required because each piece covers a different NAT class or peer population — see [docs/nat-traversal.md](docs/nat-traversal.md).
+- **STUN Port Keep-Alive** — Periodic STUN plus a TCP hold from the listen port keeps NAT mappings alive and advertises the discovered public ports for HighID. Aimed at CGNAT and full-cone NAT without UPnP; auto-suspends on symmetric or unstable remapping. Distinct from the STUN NAT-type probe that decides whether a QUIC hole-punch is worth attempting.
 - **Protocol Obfuscation** — RC4-based TCP and UDP header encryption to help with ISP throttling.
 - **Deep Links** — Opens `ed2k://` URIs and `.emulecollection` files from the OS, including while Ember is already running. Incoming links require confirm/review before opening, and pending links can be reviewed later.
 
@@ -294,14 +294,15 @@ Ember currently ships for **Windows 10 and Windows 11**. No external runtimes ar
 
 ### Port forwarding
 
-Ember uses two ports for peer communication:
+Ember uses two configured ports, plus a QUIC UDP socket that usually lands on the TCP port number:
 
 | Port | Protocol | Purpose |
 |------|----------|---------|
 | 4662 | TCP | Peer-to-peer file transfers |
 | 4672 | UDP | KAD DHT and Ember Network communication (both share this socket) |
+| 4662 (typical) | UDP | Ember QUIC — hole-punch and peer-relay. Own socket, not shared with 4672; may fall back to a neighbour port if that UDP port is taken |
 
-These are configurable in **Settings > Network**. For best performance (HighID), forward both ports on your router, enable **UPnP** so Ember maps them automatically, or leave **STUN port keep-alive** on.
+These are configurable in **Settings > Network**. For best performance (HighID), forward the TCP and KAD UDP ports on your router, enable **UPnP** so Ember maps them (and QUIC) automatically, or leave **STUN port keep-alive** on. You do not need every NAT feature on every network — UPnP, STUN, QUIC punch, buddy, and relay are fallbacks for different NAT classes; the map is in [docs/nat-traversal.md](docs/nat-traversal.md).
 
 STUN keep-alive (on by default) periodically refreshes your NAT mappings with STUN, holds a TCP connection from the listen port, and advertises the discovered public ports so peers connect to the right place. It is aimed at CGNAT and full-cone NAT where UPnP is unavailable, and auto-suspends on Open/Symmetric NAT or unstable remapping, falling back to your configured ports. Symmetric NAT or a VPN that remaps ports unstably still generally needs a VPN with a fixed forwarded port.
 
@@ -314,7 +315,7 @@ An ID is derived from your IP address and assigned by the eD2K server when Ember
 
 A Low ID routes control messages through the server instead of peer to peer, which adds overhead, and two Low ID clients cannot connect to each other at all, so you see fewer sources. On busy servers, messages can also be dropped, costing you queue progress. The ID affects control traffic only — file data always moves client to client — and past the High ID threshold a larger numeric value confers no advantage.
 
-If you are stuck on a Low ID: confirm 4662/TCP and 4672/UDP are forwarded, check your OS firewall allows Ember on both protocols, enable UPnP, and leave STUN keep-alive on. eD2K Low ID and KAD Firewalled are separate verdicts — the first is TCP reachability as judged by the server, the second is KAD's own assessment of your UDP reachability, so you can legitimately be High ID and Firewalled at once.
+If you are stuck on a Low ID: confirm 4662/TCP and 4672/UDP are forwarded, check your OS firewall allows Ember on both protocols, enable UPnP, and leave STUN keep-alive on. Two Low ID eMule clients still cannot TCP to each other; Ember-to-Ember then tries QUIC hole-punch (friends) or EPX peer-relay (downloads). eD2K Low ID and KAD Firewalled are separate verdicts — the first is TCP reachability as judged by the server, the second is KAD's own assessment of your UDP reachability, so you can legitimately be High ID and Firewalled at once.
 
 ### For developers
 
@@ -363,6 +364,7 @@ The production build writes platform packages under `src-tauri/target/release/bu
 | Database | SQLite via rusqlite |
 | Networking | Tokio async runtime |
 | Ember Overlay Transport | Noise IK / XX over UDP (ChaCha20-Poly1305 + BLAKE2s) |
+| Ember NAT / punch / relay | STUN, Quinn QUIC (`ember/1`), rendezvous punch + WebSocket relay |
 | Ember DHT | Kademlia, 128-bit BLAKE3 node IDs, Ed25519-signed frames |
 | Friend Discovery | Rendezvous server (Axum on Fly.io) |
 | Friend Sessions | Noise IK + Ed25519 proof of possession |

--- a/docs/ember-dht.md
+++ b/docs/ember-dht.md
@@ -46,7 +46,9 @@ gets in through, in rough order of who arrives first:
    **`nodes_ember.dat`** (up to `EMBER_PERSIST_MAX_CONTACTS` = 200) once
    the node has been online before.
 
-The rendezvous server is still used for *friend* NAT traversal and relay.
+The rendezvous server is still used for *friend* NAT traversal and relay
+(how that sits next to STUN, QUIC, UPnP, KAD buddy, and EPX relay is
+[docs/nat-traversal.md](nat-traversal.md)).
 It has no role in DHT bootstrap: that pool, its endpoint, and the pinned
 key it verified were deleted, because the server and client never agreed
 on the envelope format and restoring it would have handed the operator an

--- a/docs/nat-traversal.md
+++ b/docs/nat-traversal.md
@@ -1,0 +1,270 @@
+# NAT traversal — do we need QUIC, STUN, and the rest?
+
+Short answer: **a given session only uses a subset, but the stack as a
+whole is not redundant.** Each piece covers a different network, a
+different NAT class, or a different peer population. Dropping one does
+not make another take over; it just leaves a hole.
+
+The features that look similar from the Settings page — UPnP, STUN
+keep-alive, KAD firewall status, QUIC hole-punch, peer relay — are
+layered fallbacks, not alternate implementations of the same thing.
+
+```mermaid
+flowchart TD
+  inbound[Make this node reachable]
+  inbound --> osfw[Windows Firewall rules]
+  osfw --> upnp{UPnP mapped the ports?}
+  upnp -->|yes| highid[Advertise configured ports]
+  upnp -->|no, or server still assigned LowID| stunKa[STUN keep-alive]
+  stunKa --> cone{Cone NAT or CGNAT?}
+  cone -->|yes| remap[Advertise STUN-mapped public ports]
+  cone -->|symmetric / VPN remap| firewalled[Stay LowID / Firewalled]
+
+  dial[Need a connection]
+  dial --> tcp[Direct TCP to advertised port]
+  tcp -->|ok| done[Session up]
+  tcp -->|fail, Ember friend| punch{STUN type is punchable?}
+  punch -->|not Symmetric| quic[QUIC hole-punch via rendezvous]
+  punch -->|Symmetric, or punch failed| ws[Rendezvous WebSocket relay]
+  tcp -->|fail, one side HighID eMule| buddy[KAD buddy callback]
+  tcp -->|fail, Ember LowID vs LowID| erat[EPX ERAT peer relay over QUIC]
+```
+
+---
+
+## What each piece actually does
+
+### 1. Windows Firewall rules — host, not NAT
+
+[`src-tauri/src/security/firewall.rs`](../src-tauri/src/security/firewall.rs)
+adds inbound Windows Defender Firewall rules for the TCP and UDP listen
+ports. This is the OS packet filter on the same machine as Ember. A
+router forward or a STUN mapping is useless if Windows drops the packet
+before Ember sees it.
+
+No overlap with STUN or QUIC. Windows-only; Linux relies on the user
+(or the distro package) to open the ports.
+
+### 2. UPnP — install a real inbound forward
+
+[`src-tauri/src/network/upnp.rs`](../src-tauri/src/network/upnp.rs) asks
+the home gateway to forward TCP (file transfers), KAD UDP (4672 by
+default; Ember DHT shares that socket), and the QUIC UDP port once that
+endpoint has bound.
+
+UPnP is the only mechanism that *creates* an inbound mapping on a
+typical consumer router. STUN cannot do that: it only observes the
+mapping a NAT already made for an *outbound* packet. The advertise
+order in `advertised_tcp_port` therefore prefers a live UPnP mapping
+over a STUN-mapped port, except when the eD2K server has already
+assigned LowID — that is evidence the UPnP forward is not actually
+carrying traffic (CGNAT in front of a UPnP-capable inner router is the
+usual case), so STUN wins until a HighID proves the forward works.
+
+Default is **off** (`upnp_enabled: false`); the setup wizard offers it.
+Keep it as a user choice: some routers implement UPnP badly, and some
+users already forward by hand.
+
+### 3. KAD FirewallChecker — eMule protocol, not a STUN substitute
+
+[`src-tauri/src/network/kad/firewall.rs`](../src-tauri/src/network/kad/firewall.rs)
+is the eMule KAD firewall check: ask several contacts to connect back
+(`FirewalledReq` / `FirewalledRes`) and vote on the observed external
+IP and UDP port. The result is the **KAD Firewalled** flag on the
+Network page, which gates buddy selection and how this node publishes.
+
+This cannot be replaced by STUN:
+
+- Other eMule / aMule clients speak this opcode and expect it. Ember
+  has to as well, or it is not a KAD peer.
+- Votes are weighted by distinct `/24` so a Sybil cluster cannot pick
+  our advertised IP. A public STUN reflector does not give that.
+- eD2K LowID (TCP, judged by the server) and KAD Firewalled (UDP,
+  judged by peers) are independent. HighID and Firewalled at once is
+  legitimate.
+
+STUN keep-alive is deliberately not allowed to be overwritten by a
+stale KAD UDP-port vote while a STUN mapping is live
+(`stun_udp_mapping_active`).
+
+### 4. STUN NAT-type probe — decide whether to punch
+
+[`src-tauri/src/network/ember/nat.rs`](../src-tauri/src/network/ember/nat.rs)
+sends Binding requests to several public reflectors (Google,
+Cloudflare, Twilio) and classifies the NAT: Open, Full Cone,
+Restricted, Port-Restricted, Symmetric, or Unknown.
+
+That classification is the gate on Ember hole-punch. The live check is
+`nat_type != Symmetric` on *our* side — we only learn the peer's type
+after the punch request is already in flight. Symmetric NAT remaps the
+external port per destination, so a coordinated punch at a STUN-learned
+port will not land.
+
+If every reflector fails, a HighID plus a confirmed TCP connect-back is
+treated as an optimistic `PortRestricted` guess so friends on an
+otherwise punchable link are not forced straight to relay.
+
+This is **not** the same code path as keep-alive. The probe is
+classification (every ~5 minutes). Keep-alive is mapping refresh
+(every 20 seconds) and public-port advertisement.
+
+### 5. STUN mapping keep-alive — CGNAT / full-cone without UPnP
+
+[`src-tauri/src/network/ember/mapping_keepalive.rs`](../src-tauri/src/network/ember/mapping_keepalive.rs):
+
+- UDP: Binding requests from the real KAD listen socket, so the mapping
+  that is refreshed is the one KAD and Ember DHT actually use.
+- TCP: `SO_REUSEADDR` connect from the listen port (a short hold to
+  keep the mapping) plus STUN-over-TCP from that same local endpoint to
+  learn the public TCP port. Google's UDP STUN servers do not speak
+  TCP, so the TCP list is separate.
+
+On by default. Auto-suspends on Open internet (nothing to refresh) and
+on Symmetric / unstable remapping (advertising a per-destination port
+would make every connect-back miss). Aimed at CGNAT and full-cone home
+NATs where UPnP is missing or lies; that is the
+[CGNAT / NAT1](https://github.com/untaimed18/Ember-P2P/issues/41) case.
+
+Without this, those nodes stay LowID even when the NAT would have
+accepted inbound on the mapped port.
+
+### 6. QUIC — Ember-only UDP transport for punch and relay
+
+[`src-tauri/src/network/ember/quic.rs`](../src-tauri/src/network/ember/quic.rs)
+is a Quinn endpoint with an Ed25519 identity-bound self-signed cert
+(ALPN `ember/1`). It binds its **own** UDP socket, usually on
+`tcp_port`, with a few neighbour-port fallbacks if that UDP port is
+already taken by KAD. It does **not** share the KAD/Ember-DHT socket.
+
+QUIC is used for:
+
+- Coordinated hole-punch between Ember identities (friends, and friend
+  file transfers). UDP punch succeeds on far more cone NATs than TCP
+  simultaneous-open.
+- Peer-relay sessions: the third Ember node that agreed to carry
+  LowID↔LowID bytes (`relay.rs` accept loop and `connect_to_peer_relay`).
+
+It is **not** a general replacement for eD2K TCP. Content still moves
+on the eMule wire once a stream is up (`secure_stream` is the inner
+protocol; QUIC is one outer carrier alongside TCP and the WebSocket
+relay). Anonymous KAD/server sources have no Ember identity, so the
+download broker does not punch them — it goes straight to peer relay
+([`broker.rs`](../src-tauri/src/network/ember/broker.rs)).
+
+Drop QUIC and Ember-to-Ember punch plus peer-relay both disappear.
+Friends can still fall back to the rendezvous WebSocket hop; LowID↔LowID
+downloads between strangers cannot.
+
+### 7. Rendezvous punch signaling — QUIC cannot punch alone
+
+Hole-punch needs both sides to know the other's mapped address and to
+send at the same time. The rendezvous server
+([`rendezvous-server/`](../rendezvous-server/)) is that signaling
+channel: signed `/v2/punch` register / poll / ack, keyed by pairwise
+friend capabilities rather than a raw Friend ID.
+
+QUIC without this is just another outbound UDP socket. The rendezvous
+has **no** role in Ember DHT bootstrap; it is only friend presence,
+punch coordination, and the WebSocket relay below.
+
+### 8. Rendezvous WebSocket relay — last hop for friends
+
+When TCP fails and punch is skipped or misses (typical: both sides
+Symmetric, or one side has no STUN mapping yet),
+`connect_friend_with_fallback` asks the rendezvous for a WebSocket
+relay ticket. Restricted to mutually known friends so the server is
+not a general traffic proxy.
+
+This is the only path that still works when neither UDP mapping is
+stable. It costs the operator bandwidth; peer relay (next) is the
+equivalent for file downloads and spends *other users'* bandwidth
+instead.
+
+### 9. KAD buddy — eMule LowID, mixed-network peers
+
+[`src-tauri/src/network/kad/buddy.rs`](../src-tauri/src/network/kad/buddy.rs)
+is classic eMule: a firewalled node keeps a TCP session to one HighID
+buddy, who forwards `OP_CALLBACK` / `OP_REASKCALLBACKTCP` so the
+firewalled side can dial *out*. Required for transfers with aMule /
+eMule / any client that does not speak Ember QUIC or ERAT.
+
+Buddy needs **one** HighID. Two LowID eMule clients still cannot
+connect; that is an eMule-protocol limit, not something STUN or QUIC
+can paper over for non-Ember peers.
+
+### 10. EPX ERAT + connection broker — Ember LowID↔LowID downloads
+
+EPX v4 can carry signed relay attestations (`ERAT`). A node with
+**Relay for other peers** on (default on) self-signs that it will
+carry traffic. The broker collects those candidates and, when two
+Ember LowID sources cannot TCP, dials a relay over QUIC.
+
+This is the Ember answer to "both firewalled", which KAD buddy cannot
+solve. It is optional to *provide* (`relay_for_peers`); it is not
+optional to *have in the protocol* if LowID Ember users are going to
+upload to each other.
+
+Firewalled Ember DHT publishing is a separate, related path: buddy
+`PROXY_STORE` so a LowID node can still place records. See
+[ember-dht.md](ember-dht.md).
+
+---
+
+## Why they are not interchangeable
+
+| If we dropped… | What still works | What breaks |
+|---|---|---|
+| Windows Firewall rules | Everything behind a non-Windows host or a manually opened rule | Inbound on a default Windows install, even with UPnP/STUN |
+| UPnP | Manual forwards; STUN keep-alive on cone/CGNAT | Typical home routers with no hand-forwarded ports |
+| KAD FirewallChecker | STUN still learns a public mapping | KAD compatibility, buddy, honest Firewalled status |
+| STUN NAT probe | Keep-alive still refreshes mappings | Punch vs relay decision; friends on cone NATs go straight to relay or punch a Symmetric mapping and fail |
+| STUN keep-alive | UPnP and manual forwards | CGNAT / full-cone without UPnP stay LowID |
+| QUIC | Direct TCP; KAD buddy; friend WebSocket relay | Hole-punch; Ember peer-relay downloads |
+| Rendezvous punch | Direct TCP; relay | Coordinated punch (QUIC has nothing to aim at) |
+| WebSocket relay | Punch on cone NATs | Friends on Symmetric NAT / double-LowID with no punch |
+| KAD buddy | Ember-to-Ember punch/relay | Firewalled transfers with eMule/aMule |
+| ERAT peer relay | Buddy when one side is HighID | Ember LowID↔LowID downloads |
+
+STUN and KAD firewall both produce an "external IP/port", but they
+measure different things (reflector vs peer connect-back) and feed
+different consumers (punch/advertise vs KAD protocol state). UPnP and
+STUN keep-alive both try to make you reachable, but one *installs* a
+forward and the other *observes* an outbound mapping. KAD buddy and
+Ember relay both help firewalled nodes, but they talk to different
+peer populations and different topologies (one HighID vs both LowID).
+
+---
+
+## What a user actually needs to turn on
+
+Nothing extra for KAD firewall checks, buddy, QUIC, or punch — those
+run as part of Connect. User-facing toggles:
+
+| Setting | Default | When to touch it |
+|---|---|---|
+| **UPnP** | Off | Turn on if the router supports it and you do not already forward 4662/TCP and 4672/UDP |
+| **STUN port keep-alive** | On | Leave on for CGNAT / no-UPnP. Turn off only if outbound STUN is blocked (captive / locked-down LAN) |
+| **Relay for other peers** | On | Turn off if you do not want to spend upload on strangers' LowID↔LowID paths |
+
+Symmetric NAT and VPNs that remap unstably still need a VPN (or host)
+with a **fixed forwarded port**. The stack will not invent a stable
+mapping those NATs refuse to keep.
+
+---
+
+## Code map
+
+| Concern | Module |
+|---|---|
+| NAT class + UDP STUN Binding | `network/ember/nat.rs` |
+| Mapping keep-alive (UDP + TCP STUN) | `network/ember/mapping_keepalive.rs` |
+| QUIC endpoint, cert, pin | `network/ember/quic.rs` |
+| Punch connect helper | `network/ember/broker.rs` (`punch_quic_pinned`) |
+| Peer relay + rendezvous punch HTTP | `network/ember/relay.rs` |
+| Friend TCP → QUIC punch → WS relay | `network/ed2k/friend_connect.rs` |
+| LowID↔LowID download relay | `network/ember/broker.rs` (`ConnectionBroker`) |
+| UPnP TCP / KAD UDP / QUIC UDP | `network/upnp.rs` |
+| KAD FirewalledReq/Res | `network/kad/firewall.rs` |
+| eMule buddy callback | `network/kad/buddy.rs` |
+| Windows inbound rules | `security/firewall.rs` |
+| Advertise-port precedence | `network/mod.rs` (`advertised_tcp_port`, `advertised_udp_port`, `advertised_quic_port`) |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**No — a given session only uses a subset. Yes — we still need the whole stack.** QUIC, STUN, UPnP, KAD firewall checks, buddy, and relay cover different NAT classes and different peer populations. Dropping one does not make another take over.

## What this PR does

Adds [docs/nat-traversal.md](docs/nat-traversal.md) and points the README at it, so the layering is written down instead of living only in comments across `nat.rs`, `quic.rs`, `mapping_keepalive.rs`, `firewall.rs`, `buddy.rs`, and `broker.rs`.

No protocol or settings changes. Nothing was removed.

## Why they are not duplicates

| Piece | Job | If we dropped it |
|---|---|---|
| Windows Firewall rules | Host inbound allow | Default Windows install drops packets even with UPnP/STUN |
| UPnP | *Install* a router inbound forward | Typical home NAT with no manual forwards |
| KAD FirewallChecker | eMule connect-back votes → Firewalled flag / buddy | Breaks KAD compatibility; STUN is not this opcode |
| STUN NAT-type probe | Classify Open / cone / Symmetric | Punch vs relay decision is blind |
| STUN keep-alive | Refresh CGNAT/full-cone mappings and advertise remapped ports | Those nodes stay LowID (the NAT1/CGNAT case) |
| QUIC | Ember UDP transport for hole-punch and peer-relay | Friends fall back to WS relay; Ember LowID↔LowID downloads die |
| Rendezvous punch | Signaling so both sides send at once | QUIC has nothing to aim at |
| WebSocket relay | Last hop for friends on Symmetric NAT | Chat/browse between two unpunchable friends |
| KAD buddy | Firewalled transfers with eMule/aMule | Ember-only punch/relay cannot talk to those clients |
| EPX ERAT peer relay | Ember LowID↔LowID downloads | KAD buddy needs one HighID; two LowIDs still cannot TCP |

STUN and the KAD firewall check both produce an external IP, but they measure different things (reflector vs peer connect-back) and feed different consumers. UPnP and STUN keep-alive both try to make you reachable, but one creates a forward and the other observes an outbound mapping — the advertise path already prefers UPnP unless LowID proved that forward is dead. Buddy and Ember relay both help firewalled nodes, but buddy talks to eMule and needs one HighID; ERAT is Ember-only and covers both-LowID.

## What a user should actually toggle

KAD checks, buddy, QUIC, and punch run as part of Connect. The Settings knobs:

- **UPnP** — off by default; turn on if the router supports it and ports are not already forwarded
- **STUN port keep-alive** — on by default; leave it unless outbound STUN is blocked
- **Relay for other peers** — on by default; turn off to stop spending upload on strangers' LowID paths

Symmetric NAT / unstable VPN remapping still needs a fixed forwarded port. The stack will not invent a mapping those NATs refuse to keep.

## What we did not do

Did not delete unused-looking paths. The download broker already skips hole-punch for anonymous KAD sources (no Ember identity to sign a v2 punch); friends still punch. `NatType::can_punch_with` stays as the reference matrix behind tests; the live gate is `!= Symmetric` on our own type.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df21afa3-a7b0-4bdd-9b64-e967fbb17b98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df21afa3-a7b0-4bdd-9b64-e967fbb17b98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

