### PR TITLE
Fix Windows Firewall blocking inbound QUIC punch and relay

### DIFF
--- a/src-tauri/src/network/ember/nat.rs
+++ b/src-tauri/src/network/ember/nat.rs
@@ -469,6 +469,8 @@ pub(crate) fn parse_binding_response(
 
     let mut offset = 20;
     let end = 20 + msg_len;
+    let mut xor_mapped = None;
+    let mut mapped = None;
     while offset + 4 <= end {
         let attr_type = u16::from_be_bytes([data[offset], data[offset + 1]]);
         let attr_len = u16::from_be_bytes([data[offset + 2], data[offset + 3]]) as usize;
@@ -481,13 +483,13 @@ pub(crate) fn parse_binding_response(
         let attr_data = &data[offset..offset + attr_len];
         match attr_type {
             ATTR_XOR_MAPPED_ADDRESS => {
-                if let Some(addr) = parse_xor_mapped_address(attr_data) {
-                    return Ok(addr);
+                if xor_mapped.is_none() {
+                    xor_mapped = parse_xor_mapped_address(attr_data);
                 }
             }
             ATTR_MAPPED_ADDRESS => {
-                if let Some(addr) = parse_mapped_address(attr_data) {
-                    return Ok(addr);
+                if mapped.is_none() {
+                    mapped = parse_mapped_address(attr_data);
                 }
             }
             _ => {}
@@ -497,7 +499,13 @@ pub(crate) fn parse_binding_response(
         offset += padded;
     }
 
-    Err("No mapped address in response".into())
+    // RFC 5389: ignore MAPPED-ADDRESS when XOR-MAPPED-ADDRESS is present.
+    // Returning the first attribute we saw would prefer a rewritten
+    // MAPPED-ADDRESS over the XOR encoding that middleboxes cannot cheaply
+    // forge to a different value.
+    xor_mapped
+        .or(mapped)
+        .ok_or_else(|| "No mapped address in response".into())
 }
 
 fn parse_xor_mapped_address(data: &[u8]) -> Option<SocketAddr> {
@@ -802,5 +810,49 @@ mod tests {
 
         let addr = parse_binding_response(&response, &txn_id).unwrap();
         assert_eq!(addr, SocketAddr::new(IpAddr::V4(ip), port));
+    }
+
+    #[test]
+    fn xor_mapped_address_wins_over_a_leading_mapped_address() {
+        let txn_id = [0xBB; 12];
+        let magic = STUN_MAGIC_COOKIE.to_be_bytes();
+        let real_ip = std::net::Ipv4Addr::new(198, 51, 100, 9);
+        let real_port: u16 = 41234;
+        let xor_port = real_port ^ (STUN_MAGIC_COOKIE >> 16) as u16;
+        let real_octets = real_ip.octets();
+        let xor_ip = [
+            real_octets[0] ^ magic[0],
+            real_octets[1] ^ magic[1],
+            real_octets[2] ^ magic[2],
+            real_octets[3] ^ magic[3],
+        ];
+
+        let mut mapped_attr = Vec::new();
+        mapped_attr.extend_from_slice(&ATTR_MAPPED_ADDRESS.to_be_bytes());
+        mapped_attr.extend_from_slice(&8u16.to_be_bytes());
+        mapped_attr.push(0);
+        mapped_attr.push(0x01);
+        mapped_attr.extend_from_slice(&80u16.to_be_bytes());
+        mapped_attr.extend_from_slice(&[10, 0, 0, 1]);
+
+        let mut xor_attr = Vec::new();
+        xor_attr.extend_from_slice(&ATTR_XOR_MAPPED_ADDRESS.to_be_bytes());
+        xor_attr.extend_from_slice(&8u16.to_be_bytes());
+        xor_attr.push(0);
+        xor_attr.push(0x01);
+        xor_attr.extend_from_slice(&xor_port.to_be_bytes());
+        xor_attr.extend_from_slice(&xor_ip);
+
+        let attrs_len = (mapped_attr.len() + xor_attr.len()) as u16;
+        let mut response = Vec::new();
+        response.extend_from_slice(&STUN_BINDING_RESPONSE.to_be_bytes());
+        response.extend_from_slice(&attrs_len.to_be_bytes());
+        response.extend_from_slice(&magic);
+        response.extend_from_slice(&txn_id);
+        response.extend_from_slice(&mapped_attr);
+        response.extend_from_slice(&xor_attr);
+
+        let addr = parse_binding_response(&response, &txn_id).unwrap();
+        assert_eq!(addr, SocketAddr::new(IpAddr::V4(real_ip), real_port));
     }
 }

--- a/src-tauri/src/network/kad/firewall.rs
+++ b/src-tauri/src/network/kad/firewall.rs
@@ -264,6 +264,9 @@ impl FirewallChecker {
     /// `reporter` is the responding contact's source IP; votes are weighted by
     /// distinct /24 (K7) so a single-subnet cluster can't bias the result.
     pub fn handle_pong(&mut self, reported_udp_port: u16, reporter: Ipv4Addr) {
+        if reported_udp_port == 0 {
+            return;
+        }
         let o = reporter.octets();
         let reporter_net: [u8; 3] = [o[0], o[1], o[2]];
         self.udp_port_votes
@@ -492,5 +495,19 @@ mod tests {
             Some(Ipv4Addr::new(10, 0, 0, 5)),
             "LAN HighID from a local server is adoptable"
         );
+    }
+
+    #[test]
+    fn pong_ignores_reported_port_zero() {
+        let mut fw = FirewallChecker::new();
+        let reporters = [
+            Ipv4Addr::new(8, 8, 8, 8),
+            Ipv4Addr::new(1, 1, 1, 1),
+            Ipv4Addr::new(9, 9, 9, 9),
+        ];
+        for reporter in reporters {
+            fw.handle_pong(0, reporter);
+        }
+        assert!(fw.external_udp_port().is_none());
     }
 }

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -504,6 +504,9 @@ fn apply_udp_mapping_keepalive(
     }
 
     let port = mapped.port();
+    if port == 0 {
+        return false;
+    }
     // UI always shows the latest observed mapping.
     state.stats.public_udp_port = port;
 
@@ -656,6 +659,13 @@ fn tcp_port_confirmation(
     stable_hits: u8,
     observed_port: u16,
 ) -> TcpPortConfirmation {
+    if observed_port == 0 {
+        return TcpPortConfirmation {
+            candidate_port,
+            stable_hits,
+            confirmed_port: None,
+        };
+    }
     if observed_port == configured_tcp_port {
         return TcpPortConfirmation {
             candidate_port: None,
@@ -5960,6 +5970,14 @@ mod tests {
         assert_eq!(result.confirmed_port, Some(4662));
         assert_eq!(result.candidate_port, None);
         assert_eq!(result.stable_hits, 0);
+    }
+
+    #[test]
+    fn tcp_port_confirmation_ignores_port_zero() {
+        let result = tcp_port_confirmation(4662, Some(51234), 1, 0);
+        assert_eq!(result.confirmed_port, None);
+        assert_eq!(result.candidate_port, Some(51234));
+        assert_eq!(result.stable_hits, 1);
     }
 
     #[test]
@@ -24003,6 +24021,23 @@ pub async fn start_network(deps: NetworkDeps) -> anyhow::Result<()> {
                                             friend_hashes.clone(),
                                         ));
                                         tracing::info!("QUIC accept loop spawned");
+
+                                        // Windows Firewall already allows KAD UDP
+                                        // (`udp_port`) and, at startup, anticipated
+                                        // QUIC on `tcp_port`. If bind landed on a
+                                        // fallback neighbour, open that port too —
+                                        // otherwise inbound punch/relay is dropped
+                                        // even when UPnP forwarded it.
+                                        #[cfg(target_os = "windows")]
+                                        {
+                                            let fw_quic = bound_port;
+                                            let fw_kad_udp = state.udp_port;
+                                            tokio::task::spawn_blocking(move || {
+                                                crate::security::firewall::ensure_quic_udp_firewall_rule(
+                                                    fw_quic, fw_kad_udp,
+                                                );
+                                            });
+                                        }
 
                                         // Forward the QUIC UDP port via UPnP. QUIC binds
                                         // its socket here — after the initial UPnP setup

--- a/src-tauri/src/security/firewall.rs
+++ b/src-tauri/src/security/firewall.rs
@@ -6,6 +6,12 @@ use crate::security::filesystem::windows_system_path;
 
 const RULE_NAME_TCP: &str = "Ember P2P (TCP)";
 const RULE_NAME_UDP: &str = "Ember P2P (UDP)";
+/// QUIC binds its own UDP socket, usually on `tcp_port` — a different
+/// number from the KAD UDP port this module already opens. Without a
+/// dedicated inbound UDP allow, Windows drops unsolicited QUIC Initial
+/// packets: hole-punch accepts, relay-target connects, and `relay_for_peers`
+/// all fail even when UPnP forwarded the port and TCP HighID is fine.
+const RULE_NAME_QUIC_UDP: &str = "Ember P2P (QUIC UDP)";
 
 /// Spawned by absolute path, never by bare name — see
 /// [`windows_system_path`] for the planted-binary hijack this avoids.
@@ -179,7 +185,12 @@ fn add_firewall_rule(rule_name: &str, protocol: &str, port: u16) -> AddRuleOutco
 }
 
 /// Remove stale firewall rules whose port no longer matches, then ensure
-/// inbound TCP and UDP rules exist for the configured ports.
+/// inbound TCP, KAD UDP, and (when it is a distinct port) QUIC UDP rules
+/// exist for the configured ports.
+///
+/// QUIC typically binds UDP on `tcp_port`. Opening that here at startup
+/// covers the common case before the endpoint exists; [`ensure_quic_udp_firewall_rule`]
+/// updates the rule if bind later falls back to a neighbour port.
 ///
 /// When the user is *not* running elevated and the rules don't yet
 /// exist, we used to emit two raw `netsh` stderr dumps every single
@@ -198,6 +209,13 @@ pub fn ensure_firewall_rules(tcp_port: u16, udp_port: u16) {
         elevation_failures.push("UDP");
     }
 
+    if dedicated_quic_udp_port(tcp_port, udp_port).is_some() {
+        let quic_outcome = ensure_one_rule(RULE_NAME_QUIC_UDP, "UDP", tcp_port);
+        if matches!(quic_outcome, Some(AddRuleOutcome::NeedsElevation)) {
+            elevation_failures.push("QUIC");
+        }
+    }
+
     // Single consolidated WARN: same information density as the old
     // "Run as administrator" line, but emitted *once* and naming both
     // protocols. Detail-per-rule lives at debug level for support.
@@ -210,6 +228,34 @@ pub fn ensure_firewall_rules(tcp_port: u16, udp_port: u16) {
              this warning will go away.",
         );
     }
+}
+
+/// After the QUIC endpoint binds, open inbound UDP on the *actual* port.
+///
+/// No-op when that port is already the KAD UDP port (covered by
+/// [`RULE_NAME_UDP`]) or when it matches `tcp_port` already opened by
+/// [`ensure_firewall_rules`]. Recreates [`RULE_NAME_QUIC_UDP`] if bind
+/// landed on a fallback neighbour (`tcp_port+1..=+4`).
+pub fn ensure_quic_udp_firewall_rule(quic_udp_port: u16, kad_udp_port: u16) {
+    let Some(port) = dedicated_quic_udp_port(quic_udp_port, kad_udp_port) else {
+        return;
+    };
+    if matches!(
+        ensure_one_rule(RULE_NAME_QUIC_UDP, "UDP", port),
+        Some(AddRuleOutcome::NeedsElevation)
+    ) {
+        warn!(
+            "Windows Firewall rule for Ember P2P (QUIC UDP/{port}) could not be added: \
+             elevation required. Inbound hole-punch and peer-relay may be blocked until \
+             you run Ember once as Administrator.",
+        );
+    }
+}
+
+/// Dedicated QUIC UDP allow-rule is needed when QUIC is not sharing the
+/// KAD UDP port (and is actually bound).
+fn dedicated_quic_udp_port(quic_udp_port: u16, kad_udp_port: u16) -> Option<u16> {
+    (quic_udp_port != 0 && quic_udp_port != kad_udp_port).then_some(quic_udp_port)
 }
 
 /// Returns `Some(outcome)` when `add_firewall_rule` actually ran (rule
@@ -226,4 +272,21 @@ fn ensure_one_rule(rule_name: &str, protocol: &str, port: u16) -> Option<AddRule
         delete_firewall_rule(rule_name);
     }
     Some(add_firewall_rule(rule_name, protocol, port))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dedicated_quic_udp_port;
+
+    #[test]
+    fn dedicated_quic_rule_skipped_when_sharing_kad_udp_port() {
+        assert_eq!(dedicated_quic_udp_port(4672, 4672), None);
+        assert_eq!(dedicated_quic_udp_port(0, 4672), None);
+    }
+
+    #[test]
+    fn dedicated_quic_rule_needed_on_tcp_port_or_fallback() {
+        assert_eq!(dedicated_quic_udp_port(4662, 4672), Some(4662));
+        assert_eq!(dedicated_quic_udp_port(4663, 4672), Some(4663));
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Audit of the NAT/firewall stack (UPnP, STUN, QUIC punch/relay, KAD firewall/buddy, Windows Firewall). Most of it is internally consistent. Three real bugs, one of them user-visible on every Windows install.

## What was broken

**Windows Firewall never allowed inbound QUIC.** Ember opens TCP 4662 and UDP 4672. QUIC binds a *second* UDP socket, almost always on 4662. UPnP already maps that port on the router, but Windows Defender Firewall still dropped unsolicited UDP there. That breaks:

- being a `relay_for_peers` node (inbound `RELAY_REQUEST`)
- being a relay *target* (inbound `RELAY_CONNECT`)
- accepting a hole-punch when the other side dials first

Outbound punch/relay still worked (stateful UDP). HighID on TCP did not imply QUIC was reachable.

Fix: open UDP on the TCP port at startup (the usual QUIC bind), and after the endpoint actually binds, recreate the rule if it fell back to a neighbour port.

## Smaller nits

- STUN parser returned the first mapped attribute. RFC 5389 says ignore `MAPPED-ADDRESS` when `XOR-MAPPED-ADDRESS` is present (middleboxes rewrite the former).
- KAD `Pong` votes of port 0 are ignored (the UDP ingest path already skipped them; `handle_pong` itself did not).
- TCP/UDP STUN keep-alive no longer treats mapped port 0 as a confirmed advertise.

## What was checked and left alone

| Path | Verdict |
|---|---|
| STUN NAT-type probe | Sound. Distinct-reflector skip, Open vs Symmetric vs PortRestricted, HighID fallback only when STUN found no address. |
| STUN keep-alive | Sound. UPnP outranks STUN except on proven LowID; 1:1 vs remap stability; does not clobber `nat_type`. |
| UPnP | Sound. TCP + KAD UDP + QUIC UDP; refuses to steal a foreign mapping; records QUIC port before gateway exists. |
| KAD FirewallChecker | Sound. Distinct-/24 votes, connect-back vs LowID sticky, STUN remap not overwritten by pongs. |
| KAD buddy | Sound. Callback token vs routing-table mixup already fixed; idle timeout; dual buddy UDP port spray. |
| QUIC punch | Sound. Registers the QUIC socket’s public port, not the KAD STUN port; identity-pinned certs. |
| Download broker | By design starts at relay (anonymous LowID sources have no Ember identity to punch). |
| Friend WS relay | Restricted to known friends; HTTPS-only. |

Symmetric NAT still cannot punch; that is not a bug.

## Tests

Unit tests for the QUIC firewall-port helper, XOR-MAPPED preference, pong port 0, and TCP STUN port 0.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df21afa3-a7b0-4bdd-9b64-e967fbb17b98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df21afa3-a7b0-4bdd-9b64-e967fbb17b98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

